### PR TITLE
Fix for Authentication Token Never Expiring

### DIFF
--- a/common/ExampleBase.cs
+++ b/common/ExampleBase.cs
@@ -1,4 +1,4 @@
-﻿using DocuSign.eSign.Client;
+using DocuSign.eSign.Client;
 using DocuSign.eSign.Client.Auth;
 using System;
 using System.Linq;
@@ -9,10 +9,8 @@ namespace eg_01_csharp_jwt
 {
     public class ExampleBase
     {        
-        private const int TOKEN_REPLACEMENT_IN_SECONDS = 10 * 60;
-
         private static string AccessToken { get; set; }
-        private static int expiresIn;
+        private static DateTime expiresIn;
         private static Account Account { get; set; }
 
         protected static ApiClient ApiClient { get; private set; }
@@ -30,7 +28,7 @@ namespace eg_01_csharp_jwt
         public void CheckToken()
         {
             if (AccessToken == null
-                || (DateTime.Now.Millisecond + TOKEN_REPLACEMENT_IN_SECONDS) > expiresIn)
+                || (DateTime.UtcNow) > expiresIn)
             {
                 Console.WriteLine("Obtaining a new access token...");
                 UpdateToken();
@@ -52,7 +50,7 @@ namespace eg_01_csharp_jwt
 
             ApiClient = new ApiClient(Account.BaseUri + "/restapi");
             
-            expiresIn = DateTime.Now.Second + authToken.expires_in.Value;
+            expiresIn = DateTime.UtcNow.AddSeconds(authToken.expires_in.Value);
         }
 
         private Account GetAccountInfo(OAuth.OAuthToken authToken)


### PR DESCRIPTION
Originally using the DateTime.Now.Milliseconds computation would never allow the token to expire in an extended session.  I switched the expiresIn variable to a DateTime and used a comparison between two DateTimes to determine if we need a new token.  This fixed the issue and properly regenerated the auth token after it expired.