### PR TITLE
Fixes for token timeout check (token would never timeout)

### DIFF
--- a/common/ExampleBase.cs
+++ b/common/ExampleBase.cs
@@ -12,7 +12,7 @@ namespace eg_01_csharp_jwt
         private const int TOKEN_REPLACEMENT_IN_SECONDS = 10 * 60;
 
         private static string AccessToken { get; set; }
-        private static int expiresIn;
+        private static DateTime expiresIn;
         private static Account Account { get; set; }
 
         protected static ApiClient ApiClient { get; private set; }
@@ -30,7 +30,7 @@ namespace eg_01_csharp_jwt
         public void CheckToken()
         {
             if (AccessToken == null
-                || (DateTime.Now.Millisecond + TOKEN_REPLACEMENT_IN_SECONDS) > expiresIn)
+                || DateTime.UtcNow > expiresIn)
             {
                 Console.WriteLine("Obtaining a new access token...");
                 UpdateToken();
@@ -52,7 +52,7 @@ namespace eg_01_csharp_jwt
 
             ApiClient = new ApiClient(Account.BaseUri + "/restapi");
             
-            expiresIn = DateTime.Now.Second + authToken.expires_in.Value;
+            expiresIn = DateTime.UtcNow.AddSeconds(authToken.expires_in.Value);
         }
 
         private Account GetAccountInfo(OAuth.OAuthToken authToken)


### PR DESCRIPTION
The sample code is broken in that the token will never be updated when it expires in the 1 hour period.